### PR TITLE
Add Perl to Script Calls

### DIFF
--- a/fan-speed-control.pl
+++ b/fan-speed-control.pl
@@ -201,7 +201,7 @@ while () {
     # could just be a simple pipe, but hddtemp has a strong posibility
     # to be stuck in a D state, and hold STDERR open despite a kill
     # -9, so instead just send it to a tempfile, and read from that tempfile
-    system("timeout -k 1 20 hddtemp /dev/sd? /dev/nvme?n? | grep -v 'not available' > $tempfilename");
+    system("timeout -k 1 20 perl /usr/local/bin/hddtemp /dev/sd? /dev/nvme?n? | grep -v 'not available' > $tempfilename");
     @hddtemps=`cat < $tempfilename`;
   }
   if (!@ambient_ipmitemps) {

--- a/fan-speed-control.service
+++ b/fan-speed-control.service
@@ -2,7 +2,7 @@
 Description=Dell Poweredge Fan Control Daemon
 
 [Service]
-ExecStart=/usr/local/bin/fan-speed-control.pl
+ExecStart=perl /usr/local/bin/fan-speed-control.pl
 Restart=on-failure
 Type=simple
 


### PR DESCRIPTION
Originally, **hddtemp** was being called without _perl_ and the file location. Given the setup provided, this causes the script to not be found and not run.
In addition, the service doesn't use Perl to call the **fan-speed-control.pl**. Adding _perl_ to the execution will let the script actually execute.